### PR TITLE
Apply ordering before paging

### DIFF
--- a/lib/active_data_tables/active_data_tables.rb
+++ b/lib/active_data_tables/active_data_tables.rb
@@ -14,8 +14,8 @@ class ActiveDataTables
 
     filtered = @query.count
 
-    apply_paging
     apply_ordering
+    apply_paging
 
     DataTablesResult.new(@params[:draw].to_i, @query, total, filtered)
   end

--- a/spec/active_data_tables_spec.rb
+++ b/spec/active_data_tables_spec.rb
@@ -97,6 +97,29 @@ shared_examples 'active_data_tables' do
 
   end
 
+  describe 'apply sorting and paging on a single column' do
+
+    before(:each) do
+      params[:order] = {}
+      params[:order][:'0'] = { column: '0', dir: 'asc' }
+      params[:start] = 2
+      params[:length] = 1
+
+      @result = ActiveDataTables.find(subject, params)
+    end
+
+    it { expect(@result.records_total).to eq(6) }
+
+    it { expect(@result.records_filtered).to eq(6) }
+
+    it { expect(@result.data[0].date).to eq(Time.new(2014, 1, 1, 0, 0, 3)) }
+
+    it { expect(@result.data.length).to eq(1) }
+
+    it { expect(@result.data) }
+
+  end
+
 end
 
 RSpec.describe ActiveDataTables do


### PR DESCRIPTION
This ensures that the entire table is ordered not just the current page
